### PR TITLE
Fix rate limit storage and build

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A simple, secure, and ergonomic Durable Object base class for user authenticatio
 - 🧩 Easy migration, password change, and reset
 - 🗄️ Secure per-user KV store for arbitrary data
 - 🧬 **Extend and build on top** - no separate bindings needed
+- ⏱️ Basic rate limiting for authentication endpoints
 
 > **Note:**
 > - You extend `UserDO` with your own class and add your custom logic on top
@@ -254,7 +255,7 @@ Never use the example secret in production. Always set a strong, random secret f
 
 ## Potential Roadmap
 
-- [ ] Rate limiting for authentication endpoints
+- [x] Rate limiting for authentication endpoints
 - [ ] Email verification flow
 - [ ] Password reset with secure, time-limited tokens
 - [ ] Configurable JWT expiration and refresh tokens

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,5 +39,7 @@
     "declarationDir": "dist",
     "outDir": "dist",
     "rootDir": "."
-  }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["examples"]
 }


### PR DESCRIPTION
## Summary
- remove unsupported expiration option on rate limit data
- restrict ts build to src folder to avoid missing module errors
- install npm deps so `npm run check` can run

## Testing
- `npm run build`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6845763e2b28832d849cc3085300c33c