### PR TITLE
Fix missing getUserDO export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "userdo",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "repository": {
     "type": "git",
     "url": "https://github.com/acoyfellow/userdo.git"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./UserDO";
+


### PR DESCRIPTION
## Summary
- reintroduce `src/index.ts` exporting `getUserDO`
- bump version to 0.1.29

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6848519e8164832db081d19919e3e45f