### PR TITLE
Improve browser auth client

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,69 @@ if (!result.ok) {
 - Returns `{ ok: true }` for set operations
 - Keys starting with `__` are reserved for internal UserDO use
 
+
+## Browser Client Quickstart
+
+A minimal browser client is available via `userdo/client`. It mirrors the backend methods for signup, login, logout and provides helpers for database collections and real-time events.
+
+### Include from a CDN
+
+```html
+<script type="module">
+  import { UserDOClient } from "https://unpkg.com/userdo/dist/src/client.js";
+  // Base URL pointing at your worker routes
+  const api = new UserDOClient("/api");
+</script>
+```
+
+With a bundler you can import from NPM:
+
+```ts
+import { UserDOClient } from "userdo/client";
+const api = new UserDOClient("/api");
+```
+
+### Local development
+
+When running `npm run dev`, the client script is served at `/client.js`:
+
+```html
+<script type="module">
+  import { UserDOClient } from "/client.js";
+  const api = new UserDOClient("/");
+</script>
+```
+
+### Authenticate
+
+```ts
+await api.signup("alice@example.com", "password");
+// or
+await api.login("alice@example.com", "password");
+// subscribe to auth changes
+api.onAuthStateChanged(user => {
+  console.log("auth", user);
+});
+```
+Tokens are stored in `localStorage` so users remain logged in after page refreshes.
+
+### Work with collections
+
+```ts
+const posts = api.collection("posts");
+await posts.create({ title: "Hello", content: "World" });
+const list = await posts.query().orderBy("createdAt", "desc").get();
+```
+
+### Real-time updates
+
+```ts
+api.on("table:posts:create", data => console.log("new post", data));
+api.connectRealtime(); // opens /events
+```
+
+Your server should send SSE messages when `broadcast(event, data)` is called. See the example app for one approach.
+
 ## API
 
 ### Inherited UserDO Methods

--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
     ".": {
       "import": "./dist/src/index.js",
       "require": "./dist/src/index.js"
+    },
+    "./client": {
+      "import": "./dist/src/client.js",
+      "require": "./dist/src/client.js"
     }
   },
   "bugs": {
@@ -56,7 +60,7 @@
     "cf-typegen": "wrangler types",
     "check": "tsc && wrangler deploy --dry-run",
     "deploy": "wrangler deploy",
-    "dev": "wrangler dev",
+    "dev": "npm run build && wrangler dev",
     "start": "wrangler dev",
     "build": "tsc",
     "prepublishOnly": "npm run build",

--- a/src/UserDO.ts
+++ b/src/UserDO.ts
@@ -46,6 +46,7 @@ type JwtPayload = {
 export interface Env {
   JWT_SECRET: string;
   USERDO: DurableObjectNamespace;
+  ASSETS?: Fetcher;
 }
 
 // Hash email for use as DO ID to prevent PII leaking in logs

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,232 @@
+export interface AuthResponse {
+  user: { id: string; email: string };
+  token: string;
+  refreshToken: string;
+}
+
+export type Listener = (data: any) => void;
+
+export class UserDOClient {
+  private token: string | null = null;
+  private refreshToken: string | null = null;
+  private user: { id: string; email: string } | null = null;
+  private eventSource: EventSource | null = null;
+  private listeners = new Map<string, Set<Listener>>();
+  private authListeners = new Set<(user: { id: string; email: string } | null) => void>();
+  private refreshTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(private baseUrl: string) {
+    this.loadFromStorage();
+  }
+
+  private get headers() {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (this.token) headers["Authorization"] = `Bearer ${this.token}`;
+    return headers;
+  }
+
+  private persist() {
+    if (typeof localStorage === "undefined") return;
+    if (this.token) localStorage.setItem("userdo_token", this.token); else localStorage.removeItem("userdo_token");
+    if (this.refreshToken) localStorage.setItem("userdo_refresh_token", this.refreshToken); else localStorage.removeItem("userdo_refresh_token");
+  }
+
+  private loadFromStorage() {
+    if (typeof localStorage === "undefined") return;
+    const t = localStorage.getItem("userdo_token");
+    const r = localStorage.getItem("userdo_refresh_token");
+    if (t) this.token = t;
+    if (r) this.refreshToken = r;
+    if (this.token) {
+      this.updateUserFromToken();
+      this.emitAuthChange();
+    }
+  }
+
+  private decodeToken(token: string): { id: string; email: string; exp?: number } | null {
+    try {
+      const parts = token.split(".");
+      if (parts.length !== 3) return null;
+      const payload = JSON.parse(atob(parts[1]));
+      if (!payload.sub || !payload.email) return null;
+      return { id: payload.sub, email: payload.email, exp: payload.exp };
+    } catch {
+      return null;
+    }
+  }
+
+  private scheduleRefresh(exp?: number) {
+    if (!exp || !this.refreshToken) return;
+    const ms = exp * 1000 - Date.now() - 5000;
+    if (ms <= 0) return;
+    if (this.refreshTimeout) clearTimeout(this.refreshTimeout);
+    this.refreshTimeout = setTimeout(() => this.refreshAccessToken(), ms);
+  }
+
+  private updateUserFromToken() {
+    if (!this.token) {
+      this.user = null;
+      return;
+    }
+    const info = this.decodeToken(this.token);
+    if (!info) {
+      this.user = null;
+      return;
+    }
+    this.user = { id: info.id, email: info.email };
+    this.scheduleRefresh(info.exp);
+  }
+
+  private emitAuthChange() {
+    this.authListeners.forEach((l) => l(this.user));
+  }
+
+  onAuthStateChanged(listener: (user: { id: string; email: string } | null) => void) {
+    this.authListeners.add(listener);
+    listener(this.user);
+  }
+
+  offAuthStateChanged(listener: (user: { id: string; email: string } | null) => void) {
+    this.authListeners.delete(listener);
+  }
+
+  private async refreshAccessToken() {
+    if (!this.refreshToken) return;
+    try {
+      const res = await fetch(`${this.baseUrl}/refresh`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refreshToken: this.refreshToken })
+      });
+      if (!res.ok) throw new Error(await res.text());
+      const data: { token?: string } = await res.json();
+      if (data.token) {
+        this.token = data.token;
+        this.persist();
+        this.updateUserFromToken();
+        this.emitAuthChange();
+      }
+    } catch {
+      this.logout();
+    }
+  }
+
+  async signup(email: string, password: string): Promise<AuthResponse> {
+    const res = await fetch(`${this.baseUrl}/signup`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password })
+    });
+    if (!res.ok) throw new Error(await res.text());
+    const data = (await res.json()) as AuthResponse;
+    this.token = data.token;
+    this.refreshToken = data.refreshToken;
+    this.persist();
+    this.updateUserFromToken();
+    this.emitAuthChange();
+    return data;
+  }
+
+  async login(email: string, password: string): Promise<AuthResponse> {
+    const res = await fetch(`${this.baseUrl}/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password })
+    });
+    if (!res.ok) throw new Error(await res.text());
+    const data = (await res.json()) as AuthResponse;
+    this.token = data.token;
+    this.refreshToken = data.refreshToken;
+    this.persist();
+    this.updateUserFromToken();
+    this.emitAuthChange();
+    return data;
+  }
+
+  async logout(): Promise<void> {
+    await fetch(`${this.baseUrl}/logout`, {
+      method: "POST",
+      headers: this.headers
+    });
+    this.token = null;
+    this.refreshToken = null;
+    this.user = null;
+    if (this.refreshTimeout) {
+      clearTimeout(this.refreshTimeout);
+      this.refreshTimeout = null;
+    }
+    this.persist();
+    this.emitAuthChange();
+  }
+
+  on(event: string, listener: Listener) {
+    if (!this.listeners.has(event)) this.listeners.set(event, new Set());
+    this.listeners.get(event)!.add(listener);
+  }
+
+  off(event: string, listener: Listener) {
+    this.listeners.get(event)?.delete(listener);
+  }
+
+  connectRealtime() {
+    if (this.eventSource) return;
+    this.eventSource = new EventSource(`${this.baseUrl}/events`);
+    this.eventSource.onmessage = (ev: MessageEvent) => {
+      const data = typeof ev.data === "string" ? ev.data : "";
+      if (!data) return;
+      const parsed = JSON.parse(data);
+      const listeners = this.listeners.get(ev.type) || new Set();
+      listeners.forEach(l => l(parsed));
+    };
+  }
+
+  collection(name: string) {
+    const base = `${this.baseUrl}/${name}`;
+    const client = this;
+    return {
+      async create(data: any) {
+        const res = await fetch(base, { method: "POST", headers: client.headers, body: JSON.stringify(data) });
+        if (!res.ok) throw new Error(await res.text());
+        return res.json();
+      },
+      async findById(id: string) {
+        const res = await fetch(`${base}/${id}`, { headers: client.headers });
+        if (!res.ok) throw new Error(await res.text());
+        return res.json();
+      },
+      async update(id: string, updates: any) {
+        const res = await fetch(`${base}/${id}`, { method: "PUT", headers: client.headers, body: JSON.stringify(updates) });
+        if (!res.ok) throw new Error(await res.text());
+        return res.json();
+      },
+      async delete(id: string) {
+        await fetch(`${base}/${id}`, { method: "DELETE", headers: client.headers });
+      },
+      query() {
+        const params: Record<string, any> = {};
+        return {
+          where(field: string, op: string, value: any) {
+            params["where"] = JSON.stringify([field, op, value]);
+            return this;
+          },
+          orderBy(field: string, dir: "asc" | "desc" = "asc") {
+            params["order"] = `${field}:${dir}`;
+            return this;
+          },
+          limit(count: number) {
+            params["limit"] = count;
+            return this;
+          },
+          async get() {
+            const qs = new URLSearchParams(params as any).toString();
+            const res = await fetch(`${base}?${qs}`, { headers: client.headers });
+            if (!res.ok) throw new Error(await res.text());
+            return res.json();
+          }
+        };
+      }
+    };
+  }
+}
+
+export default UserDOClient;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,5 @@ export { UserDO, getUserDO, hashEmailForId, migrateUserEmail } from "./UserDO";
 export { UserDODatabase } from "./database/index";
 export { GenericTable } from "./database/table";
 export { GenericQuery } from "./database/query";
+export { UserDOClient } from "./client";
 

--- a/src/raw.d.ts
+++ b/src/raw.d.ts
@@ -1,0 +1,4 @@
+declare module '*.js?raw' {
+  const content: string;
+  export default content;
+}

--- a/src/worker.tsx
+++ b/src/worker.tsx
@@ -2,6 +2,7 @@ import { Hono, Context } from 'hono'
 import { getCookie, setCookie, deleteCookie } from 'hono/cookie'
 import { Env, UserDO as BaseUserDO } from './UserDO'
 import { z } from 'zod'
+import clientJs from '../dist/src/client.js?raw'
 
 // Extend UserDO with database table functionality
 const PostSchema = z.object({
@@ -54,6 +55,11 @@ const getMyAppDO = (c: Context, email: string) => {
 }
 
 const app = new Hono<{ Bindings: Env, Variables: { user: User } }>()
+
+// Serve the browser client script for local development
+app.get('/client.js', (c) =>
+  c.text(clientJs, 200, { 'Content-Type': 'application/javascript' })
+)
 
 // --- AUTH ENDPOINTS ---
 app.post('/signup', async (c) => {
@@ -334,6 +340,7 @@ app.get('/', async (c) => {
           }
         `
         }}></script>
+        <script type="module" src="/client.js"></script>
       </head>
       <body>
         <h1>UserDO Demo with Database Tables</h1>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "target": "es2021",
     /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     "lib": [
-      "es2021"
+      "es2021",
+      "dom"
     ],
     /* Specify what JSX code is generated. */
     "jsx": "react-jsx",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,6 +7,10 @@
     "nodejs_compat"
   ],
   "upload_source_maps": true,
+  "assets": {
+    "directory": "dist",
+    "binding": "ASSETS"
+  },
   "migrations": [
     {
       "new_sqlite_classes": [


### PR DESCRIPTION
## Summary
- keep tokens in localStorage and restore on page load
- add auth change listener with automatic refresh using `/refresh`
- mention persistent auth in README
- enable DOM types for the browser client
- serve `/client.js` in example worker for local dev
- build before dev for convenience

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684db50cbdfc832d9f7ed5e5c6986ad6