### PR TITLE
Loosen types for new wrangler version

### DIFF
--- a/src/UserDO.ts
+++ b/src/UserDO.ts
@@ -45,7 +45,7 @@ type JwtPayload = {
 
 export interface Env {
   JWT_SECRET: string;
-  USERDO: DurableObjectNamespace;
+  USERDO: DurableObjectNamespace<Any>;
   ASSETS?: Fetcher;
 }
 


### PR DESCRIPTION
Newest wrangler types now imports your durable object's types in the `worker-configuration.d.ts`

``` typescript
declare namespace Cloudflare {
	interface Env {
		JWT_SECRET: string;
		USERDO: DurableObjectNamespace<import("./src/index").LockInDO>;
	}
}
```

this causes a type error of

```
Argument of type 'Env' is not assignable to parameter of type '.../node_modules/userdo/dist/src/UserDO").Env'.
  Types of property 'USERDO' are incompatible.
    Type 'DurableObjectNamespace<LockInDO>' is not assignable to type 'DurableObjectNamespace<undefined>'.
      Type 'LockInDO' is not assignable to type 'undefined'.
```
