### PR TITLE
Add separate client/server exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ bun install userdo
 A Durable Object is like a mini-server that lives on Cloudflare's edge. Each user gets their own instance with their own database. You extend `UserDO` to add your business logic:
 
 ```ts
-import { UserDO, type Env } from "userdo";
+import { UserDO, type Env } from "userdo/server";
 import { z } from "zod";
 
 // Define your data schema
@@ -61,7 +61,7 @@ export class BlogDO extends UserDO {
 The Worker handles HTTP requests and routes them to the right user's Durable Object. It comes with built-in auth endpoints and you add your own:
 
 ```ts
-import { createUserDOWorker, createWebSocketHandler } from 'userdo';
+import { createUserDOWorker, createWebSocketHandler } from 'userdo/server';
 
 // Create the HTTP server with built-in auth endpoints
 const app = createUserDOWorker('BLOG_DO');
@@ -207,7 +207,7 @@ Multiple isolated projects - How to run multiple independent applications using 
 ## Browser Client
 
 ```ts
-import { UserDOClient } from 'userdo';
+import { UserDOClient } from 'userdo/client';
 
 const client = new UserDOClient('/api');
 

--- a/examples/effect/src/worker.ts
+++ b/examples/effect/src/worker.ts
@@ -1,5 +1,5 @@
 import { Effect } from "effect";
-import { UserDO, getUserDO } from "userdo";
+import { UserDO, getUserDO } from "userdo/server";
 import { z } from "zod";
 
 const email = "demo@example.com";

--- a/examples/multi-tenant/index.ts
+++ b/examples/multi-tenant/index.ts
@@ -1,4 +1,4 @@
-import { createUserDOWorker, getUserDOFromContext, UserDO } from 'userdo';
+import { createUserDOWorker, getUserDOFromContext, UserDO } from 'userdo/server';
 import { z } from 'zod';
 
 // Same schema, different tenants

--- a/examples/organizations/index.tsx
+++ b/examples/organizations/index.tsx
@@ -1,4 +1,4 @@
-import { UserDO, createUserDOWorker, createWebSocketHandler, getUserDOFromContext, type Env as BaseEnv } from 'userdo';
+import { UserDO, createUserDOWorker, createWebSocketHandler, getUserDOFromContext, type Env as BaseEnv } from 'userdo/server';
 import { z } from 'zod';
 import type { Context } from 'hono';
 import {

--- a/examples/react-vite/src/worker/index.ts
+++ b/examples/react-vite/src/worker/index.ts
@@ -1,4 +1,4 @@
-import { createUserDOWorker, createWebSocketHandler, getUserDOFromContext, UserDO, type Env, type Table, broadcastToUser } from 'userdo';
+import { createUserDOWorker, createWebSocketHandler, getUserDOFromContext, UserDO, type Env, type Table, broadcastToUser } from 'userdo/server';
 import { z } from 'zod';
 import { Context } from 'hono';
 

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
   },
   "exports": {
     ".": {
+      "browser": "./dist/src/client.js",
       "import": "./dist/src/index.js",
-      "require": "./dist/src/index.js",
-      "browser": "./dist/src/client.js"
+      "require": "./dist/src/index.js"
     },
     "./client": {
       "import": "./dist/src/client.js",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,16 @@
   "exports": {
     ".": {
       "import": "./dist/src/index.js",
-      "require": "./dist/src/index.js"
+      "require": "./dist/src/index.js",
+      "browser": "./dist/src/client.js"
     },
     "./client": {
       "import": "./dist/src/client.js",
       "require": "./dist/src/client.js"
+    },
+    "./server": {
+      "import": "./dist/src/server.js",
+      "require": "./dist/src/server.js"
     },
     "./worker": {
       "import": "./dist/src/worker.js",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,10 @@
+export { UserDO, getUserDO, hashEmailForId, migrateUserEmail, type Env } from './UserDO';
+export { UserDODatabase } from './database/index';
+export { GenericTable, type Table } from './database/table';
+export { GenericQuery } from './database/query';
+
+// Worker exports
+export { userDOWorker, createUserDOWorker, createWebSocketHandler, getUserDOFromContext, broadcastToUser } from './worker';
+export { createAuthMiddleware } from './authMiddleware';
+export type { UserDOEndpoints, EndpointRequest, EndpointResponse, EndpointQuery } from './worker-types';
+export * from './worker-types';


### PR DESCRIPTION
## Summary
- add a server-only entry point
- expose a browser build via the `browser` condition in package.json
- document the new import paths in the README
- update examples to use `userdo/server`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d0e24edc4832d960fb1868486b72c